### PR TITLE
Fix mysql failing because of missing password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
         - MYSQL_DATABASE
         - MYSQL_USER
         - MYSQL_PASSWORD
+        - MYSQL_ROOT_PASSWORD
         - MYSQL_RANDOM_ROOT_PASSWORD
 
 networks:


### PR DESCRIPTION
env.example sets MYSQL_ROOT_PASSWORD, so let's also use this in
docker-compose.yml