### PR TITLE
Fix creation of docker container on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Make sure that apache-envvars is checked out with Unix line endings.